### PR TITLE
API Addition to fix Issue #16, adding sendFax calls that use input streams rather than files

### DIFF
--- a/src/main/java/net/interfax/rest/client/InterFAX.java
+++ b/src/main/java/net/interfax/rest/client/InterFAX.java
@@ -15,6 +15,7 @@ import net.interfax.rest.client.exception.UnsuccessfulStatusCodeException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 
 public interface InterFAX {
@@ -45,7 +46,7 @@ public interface InterFAX {
     public APIResponse sendFax(final String faxNumber,
                                final File fileToSendAsFax,
                                final Optional<SendFaxOptions> options) throws IOException;
-
+    
     /**
      * Send an array of files as a fax
      *
@@ -56,6 +57,18 @@ public interface InterFAX {
      * @see <a href="https://www.interfax.net/en/dev/rest/reference/2918">https://www.interfax.net/en/dev/rest/reference/2918</a>
      */
     public APIResponse sendFax(final String faxNumber, final File[] filesToSendAsFax) throws IOException;
+
+    /**
+     * Send an array of input streams as a fax
+     *
+     * @param faxNumber        number to fax to
+     * @param streamsToSendAsFax array of input streams to send as fax
+     * @param fileNames array of file names corresponding to the input streams (for mime detection)
+     * @return {@link APIResponse}
+     * @throws IOException
+     * @see <a href="https://www.interfax.net/en/dev/rest/reference/2918">https://www.interfax.net/en/dev/rest/reference/2918</a>
+     */
+    public APIResponse sendFax(final String faxNumber, final InputStream[] streamsToSendAsFax, final String fileNames[]) throws IOException;
 
     /**
      * Send an array of files as a fax with additional {@link SendFaxOptions}
@@ -69,6 +82,22 @@ public interface InterFAX {
      */
     public APIResponse sendFax(final String faxNumber,
                                final File[] filesToSendAsFax,
+                               final Optional<SendFaxOptions> options) throws IOException;
+
+    /**
+     * Send an array of files as a fax with additional {@link SendFaxOptions}
+     *
+     * @param faxNumber        number to fax to
+     * @param streamsToSendAsFax array of files to send as fax
+     * @param fileNames array of file names corresponding to the input streams (for mime detection)
+     * @param options          {@link SendFaxOptions} to use when sending the fax
+     * @return {@link APIResponse}
+     * @throws IOException
+     * @see <a href="https://www.interfax.net/en/dev/rest/reference/2918">https://www.interfax.net/en/dev/rest/reference/2918</a>
+     */
+    public APIResponse sendFax(final String faxNumber,
+                               final InputStream[] streamsToSendAsFax,
+                               final String fileNames[],
                                final Optional<SendFaxOptions> options) throws IOException;
 
     /**

--- a/src/test/java/net/interfax/rest/client/impl/DefaultInterFAXClientTest.java
+++ b/src/test/java/net/interfax/rest/client/impl/DefaultInterFAXClientTest.java
@@ -21,6 +21,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.Optional;
 
 
@@ -87,6 +89,42 @@ public class DefaultInterFAXClientTest {
 
         InterFAX interFAX = new DefaultInterFAXClient();
         APIResponse apiResponse = interFAX.sendFax(faxNumber, files, Optional.of(sendFaxOptions));
+        Assert.assertEquals("[https://rest.interfax.net/outbound/faxes/667457707]", apiResponse.getHeaders().get("Location").toString());
+        Assert.assertEquals(201, apiResponse.getStatusCode());
+
+    }
+    
+    @Test
+    public void testSendMultipleInputStreamsAsFax() throws Exception {
+
+        String absoluteFilePath = this.getClass().getClassLoader().getResource("test.pdf").getFile();
+        InputStream inputStream1 = new FileInputStream(absoluteFilePath);
+        InputStream inputStream2 = new FileInputStream(absoluteFilePath);
+
+        InputStream[] inputStreams = {inputStream1, inputStream2};
+        String[] fileNames = {"test.pdf", "test.pdf"};
+
+        InterFAX interFAX = new DefaultInterFAXClient();
+        APIResponse apiResponse = interFAX.sendFax(faxNumber, inputStreams, fileNames);
+        Assert.assertEquals("[https://rest.interfax.net/outbound/faxes/667457707]", apiResponse.getHeaders().get("Location").toString());
+        Assert.assertEquals(201, apiResponse.getStatusCode());
+    }
+
+    @Test
+    public void testSendMultipleInputStreamsAsFaxWithOptions() throws Exception {
+
+        String absoluteFilePath = this.getClass().getClassLoader().getResource("test.pdf").getFile();
+        InputStream inputStream1 = new FileInputStream(absoluteFilePath);
+        InputStream inputStream2 = new FileInputStream(absoluteFilePath);
+
+        InputStream[] inputStreams = {inputStream1, inputStream2};
+        String[] fileNames = {"test.pdf", "test.pdf"};
+
+        SendFaxOptions sendFaxOptions = new SendFaxOptions();
+        sendFaxOptions.setPageSize(Optional.of("a4"));
+
+        InterFAX interFAX = new DefaultInterFAXClient();
+        APIResponse apiResponse = interFAX.sendFax(faxNumber, inputStreams, fileNames, Optional.of(sendFaxOptions));
         Assert.assertEquals("[https://rest.interfax.net/outbound/faxes/667457707]", apiResponse.getHeaders().get("Location").toString());
         Assert.assertEquals(201, apiResponse.getStatusCode());
 


### PR DESCRIPTION
This is a fix for issue #16, which I opened myself.

The issue was that there was no obvious way to do what I had been able to with the old API, which was to send documents that were in memory without writing them as files.

This adds two additional sendFax methods, each of which takes an array of input streams and a corresponding array of file names that provide mime hints.

I have successfully used these methods to send faxes with several types of document, and have verified that they work as one would expect.

Also included are unit tests for the added methods.